### PR TITLE
Change openat(2) errno expectations on FreeBSD.

### DIFF
--- a/capsicum-freebsd.h
+++ b/capsicum-freebsd.h
@@ -34,8 +34,13 @@ typedef unsigned long cap_ioctl_t;
 // Use fexecve_() in tests to allow Linux variant to bypass glibc version.
 #define fexecve_(F, A, E) fexecve(F, A, E)
 
-// Failure to open file due to path traversal generates ENOTCAPABLE
-#define E_NO_TRAVERSE ENOTCAPABLE
+// Failure to open file due to path traversal generates ENOTCAPABLE if due to
+// capability mode or EPERM if due to EPERM.
+#define E_NO_TRAVERSE_CAPABILITY ENOTCAPABLE
+#define E_NO_TRAVERSE_O_BENEATH EPERM
+
+// Too many links
+#define E_TOO_MANY_LINKS EMLINK
 
 // TODO(FreeBSD): uncomment if/when FreeBSD propagates rights on accept.
 // FreeBSD does not generate a capability from accept(cap_fd,...).

--- a/capsicum-linux.h
+++ b/capsicum-linux.h
@@ -22,7 +22,11 @@
 #define AT_SYSCALLS_IN_CAPMODE
 
 // Failure to open file due to path traversal generates EPERM
-#define E_NO_TRAVERSE EPERM
+#define E_NO_TRAVERSE_CAPABILITY EPERM
+#define E_NO_TRAVERSE_O_BENEATH EPERM
+
+// Too many links
+#define E_TOO_MANY_LINKS ELOOP
 
 #endif /* __linux__ */
 

--- a/capsicum-test.h
+++ b/capsicum-test.h
@@ -152,7 +152,15 @@ void MaybeRunWithThread(Function fn) {
 
 // Expect a system call to fail due to path traversal; exact error
 // code is OS-specific.
-#define EXPECT_FAIL_TRAVERSAL(C) EXPECT_SYSCALL_FAIL(E_NO_TRAVERSE, C)
+#define EXPECT_FAIL_TRAVERSAL(fd, path, flags) \
+  do { \
+    const int result = openat(fd, path, flags); \
+    if ((flags & O_BENEATH) == O_BENEATH) { \
+      EXPECT_SYSCALL_FAIL(E_NO_TRAVERSE_O_BENEATH, result); \
+    } else { \
+      EXPECT_SYSCALL_FAIL(E_NO_TRAVERSE_CAPABILITY, result); \
+    } \
+  } while (0)
 
 // Expect a system call to fail with ECAPMODE.
 #define EXPECT_CAPMODE(C) EXPECT_SYSCALL_FAIL(ECAPMODE, C)


### PR DESCRIPTION
FreeBSD sets (or actually, _will_ set) errno to EPERM when O_BENEATH is
passed to openat(2) and ECAPMODE/ENOTCAPABLE otherwise. Modify the test
suite to distinguish between these possible cases (and conflate them on
Linux).
