### PR TITLE
Query GCC for the default library dir

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,8 @@ ARCHFLAG=-m$(ARCH)
 
 ifeq ($(OS),Linux)
 PROCESSOR:=$(shell uname -p)
-PLATFORM_LIBDIR=lib/$(PROCESSOR)-linux-gnu
+# PLATFORM_LIBDIR=lib/$(PROCESSOR)-linux-gnu
+PLATFORM_LIBDIR?=$(shell gcc -v 2>&1 | grep "Configured with:" | perl -pe 's/.*--libdir=\/usr\/([^\s]+).*/\1/g')
 
 # Override for explicitly specified ARCHFLAG.
 # Use locally compiled libcaprights in this case, on the


### PR DESCRIPTION
This might be wrong on systems where GCC is not the default compiler but
should work on almost all Linux distributions

This fixes the build on openSUSE and should work on Debian/Ubuntu as well but I didn't test that case.
