### PR TITLE
Track FreeBSD header rename sys/capability.h -> sys/capsicum.h

### DIFF
--- a/capsicum-freebsd.h
+++ b/capsicum-freebsd.h
@@ -12,7 +12,12 @@ extern "C" {
 /* FreeBSD definitions. */
 #include <errno.h>
 #include <sys/param.h>
+#if __FreeBSD_version >= 1100014 || \
+    (__FreeBSD_version >= 1001511 && __FreeBSD_version < 1100000)
+#include <sys/capsicum.h>
+#else
 #include <sys/capability.h>
+#endif
 #include <sys/procdesc.h>
 
 #if __FreeBSD_version >= 1000000

--- a/capsicum-rights.h
+++ b/capsicum-rights.h
@@ -6,7 +6,13 @@ extern "C" {
 #endif
 
 #ifdef __FreeBSD__
+#include <sys/param.h>
+#if __FreeBSD_version >= 1100014 || \
+    (__FreeBSD_version >= 1001511 && __FreeBSD_version < 1100000)
+#include <sys/capsicum.h>
+#else
 #include <sys/capability.h>
+#endif
 #endif
 
 #ifdef __linux__


### PR DESCRIPTION
In FreeBSD r263232 sys/capability.h was renamed sys/capsicum.h to avoid
potential conflict with the draft POSIX.1e capability.h used on some
systems (e.g. Linux).