### PR TITLE
Fix ps command to retrieve zombie process state

### DIFF
--- a/capsicum-test.cc
+++ b/capsicum-test.cc
@@ -50,9 +50,11 @@ char ProcessState(int pid) {
 #endif
 #ifdef __FreeBSD__
   char buffer[1024];
-  /* 
-   * XXX: -a is used with ps(1) as a temporary workaround for retrieving the
-   * state of zombie processes
+  /*
+   * TODO(#19): Pdfork.Simple fails on FreeBSD because zombie processes are
+   * not reported by ps(1). As a temporary workaround, -a is used to retrieve
+   * the state of zombie processes. Remove this once FreeBSD starts reporting
+   * zombie processes with "sysctl kern.proc.pid.<pid>".
    */
   snprintf(buffer, sizeof(buffer), "ps -a -p %d -o state | grep -v STAT", pid);
   sig_t original = signal(SIGCHLD, SIG_IGN);

--- a/capsicum-test.cc
+++ b/capsicum-test.cc
@@ -50,7 +50,11 @@ char ProcessState(int pid) {
 #endif
 #ifdef __FreeBSD__
   char buffer[1024];
-  snprintf(buffer, sizeof(buffer), "ps -p %d -o state | grep -v STAT", pid);
+  /* 
+   * XXX: -a is used with ps(1) as a temporary workaround for retrieving the
+   * state of zombie processes
+   */
+  snprintf(buffer, sizeof(buffer), "ps -a -p %d -o state | grep -v STAT", pid);
   sig_t original = signal(SIGCHLD, SIG_IGN);
   FILE* cmd = popen(buffer, "r");
   usleep(50000);  // allow any pending SIGCHLD signals to arrive

--- a/capsicum-test.cc
+++ b/capsicum-test.cc
@@ -51,7 +51,7 @@ char ProcessState(int pid) {
 #ifdef __FreeBSD__
   char buffer[1024];
   /*
-   * TODO(#19): Pdfork.Simple fails on FreeBSD because zombie processes are
+   * TODO(#18): Pdfork.Simple fails on FreeBSD because zombie processes are
    * not reported by ps(1). As a temporary workaround, -a is used to retrieve
    * the state of zombie processes. Remove this once FreeBSD starts reporting
    * zombie processes with "sysctl kern.proc.pid.<pid>".


### PR DESCRIPTION
On FreeBSD, `$ ps -p <zombie pid> -o state` returns nothing because `sysctl kern.proc.pid.<pid>` returns nothing for a zombie pid. The `-a` flag is a temporary workaround.