### PR TITLE
Remove -ansi from CXXFLAGS

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ OBJECTS=capsicum-test-main.o capsicum-test.o capability-fd.o fexecve.o procdesc.
 GTEST_DIR=gtest-1.6.0
 GTEST_INCS=-I$(GTEST_DIR)/include -I$(GTEST_DIR)
 GTEST_FLAGS=-DGTEST_USE_OWN_TR1_TUPLE=1 -DGTEST_HAS_TR1_TUPLE=1
-CXXFLAGS+=$(ARCHFLAG) -Wall -g -ansi $(GTEST_INCS) $(GTEST_FLAGS)
+CXXFLAGS+=$(ARCHFLAG) -Wall -g $(GTEST_INCS) $(GTEST_FLAGS)
 CFLAGS+=$(ARCHFLAG) -Wall -g
 
 capsicum-test: $(OBJECTS) libgtest.a $(LOCAL_LIBS)


### PR DESCRIPTION
clang doesn't support earlier versions of the C++ spec (`-ansi` implies
C++90) and emits a warning (which results in a failure with -Werror) when this
flag is present. Remove it so the compile passes with clang++ and other
modern compilers.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>