### PR TITLE
Ensure that mknod(2) is called with S_IFIFO in `mode`

### DIFF
--- a/capmode.cc
+++ b/capmode.cc
@@ -80,7 +80,7 @@ FORK_TEST_F(WithFiles, DisallowedFileSyscalls) {
   EXPECT_CAPMODE(link(TmpFile("foo"), TmpFile("bar")));
   struct stat sb;
   EXPECT_CAPMODE(lstat(TmpFile("cap_capmode_lstat"), &sb));
-  EXPECT_CAPMODE(mknod(TmpFile("capmode_mknod"), 0644, 0));
+  EXPECT_CAPMODE(mknod(TmpFile("capmode_mknod"), 0644 | S_IFIFO, 0));
   EXPECT_CAPMODE(bogus_mount_());
   EXPECT_CAPMODE(open("/dev/null", O_RDWR));
   char buf[64];


### PR DESCRIPTION
This prevents the test from failing with a false positive, i.e., -1/EINVAL,
as the file type was not specified prior to this commit. Other
alternatives (use S_IFBLK, S_IFCHR) is not possible, unless executing as
root, so use fifos instead (which can be done by all users.

This unbreaks the test on FreeBSD 13.0-CURRENT and fixes #15.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>