### PR TITLE
Fix errno used when checking for failure with `O_BENEATH`

### DIFF
--- a/capsicum-freebsd.h
+++ b/capsicum-freebsd.h
@@ -49,10 +49,8 @@ typedef unsigned long cap_ioctl_t;
 #define E_NO_TRAVERSE_CAPABILITY ENOTBENEATH
 #define E_NO_TRAVERSE_O_BENEATH ENOTBENEATH
 #else
-// Failure to open file due to path traversal generates ENOTCAPABLE if due to
-// capability mode or EPERM if due to EPERM.
 #define E_NO_TRAVERSE_CAPABILITY ENOTCAPABLE
-#define E_NO_TRAVERSE_O_BENEATH EPERM
+#define E_NO_TRAVERSE_O_BENEATH ENOTCAPABLE
 #endif
 
 // FreeBSD limits the number of ioctls in cap_ioctls_limit to 256


### PR DESCRIPTION
Per open(2), the errno that should be tested is `ENOTCAPABLE`, not
`EPERM`.

This addresses the first set of failures noted in #28, which account for
all failures in the openat(2) testcases, sans two in the second set of
failures.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>