### PR TITLE
Create a temporary directory root at start if not specified via -T

### DIFF
--- a/capability-fd.cc
+++ b/capability-fd.cc
@@ -291,7 +291,7 @@ FORK_TEST(Capability, BasicInterception) {
 }
 
 FORK_TEST_ON(Capability, OpenAtDirectoryTraversal, TmpFile("cap_openat_testfile")) {
-  int dir = open(tmpdir, O_RDONLY);
+  int dir = open(tmpdir.c_str(), O_RDONLY);
   EXPECT_OK(dir);
 
   cap_enter();
@@ -358,7 +358,7 @@ FORK_TEST_ON(Capability, FileInSync, TmpFile("cap_file_sync")) {
 // Create a capability on /tmp that does not allow CAP_WRITE,
 // and check that this restriction is inherited through openat().
 FORK_TEST_ON(Capability, Inheritance, TmpFile("cap_openat_write_testfile")) {
-  int dir = open(tmpdir, O_RDONLY);
+  int dir = open(tmpdir.c_str(), O_RDONLY);
   EXPECT_OK(dir);
 
   cap_rights_t r_rl;
@@ -902,7 +902,7 @@ void DirOperationsTest(int extra) {
   if (rc < 0 && errno != EEXIST) return;
   int dfd = open(TmpFile("cap_dirops"), O_RDONLY | O_DIRECTORY | extra);
   EXPECT_OK(dfd);
-  int tmpfd = open(tmpdir, O_RDONLY | O_DIRECTORY);
+  int tmpfd = open(tmpdir.c_str(), O_RDONLY | O_DIRECTORY);
   EXPECT_OK(tmpfd);
 
   EXPECT_OK(cap_enter());  // Enter capability mode.

--- a/capmode.cc
+++ b/capmode.cc
@@ -28,7 +28,7 @@ class WithFiles : public ::testing::Test {
   WithFiles() :
     fd_file_(open(TmpFile("cap_capmode"), O_RDWR|O_CREAT, 0644)),
     fd_close_(open("/dev/null", O_RDWR)),
-    fd_dir_(open(tmpdir, O_RDONLY)),
+    fd_dir_(open(tmpdir.c_str(), O_RDONLY)),
     fd_socket_(socket(PF_INET, SOCK_DGRAM, 0)),
     fd_tcp_socket_(socket(PF_INET, SOCK_STREAM, 0)) {
     EXPECT_OK(fd_file_);

--- a/capsicum-test.cc
+++ b/capsicum-test.cc
@@ -9,7 +9,6 @@
 #include <string>
 
 bool verbose = false;
-const char *tmpdir = "/tmp";
 bool tmpdir_on_tmpfs = false;
 bool force_mt = false;
 bool force_nofork = false;
@@ -22,7 +21,7 @@ std::map<std::string, std::string> tmp_paths;
 const char *TmpFile(const char *p) {
   std::string pathname(p);
   if (tmp_paths.find(pathname) == tmp_paths.end()) {
-    std::string fullname = std::string(tmpdir) + "/" + pathname;
+    std::string fullname = tmpdir + "/" + pathname;
     tmp_paths[pathname] = fullname;
   }
   return tmp_paths[pathname].c_str();

--- a/capsicum-test.h
+++ b/capsicum-test.h
@@ -14,7 +14,7 @@
 #include "gtest/gtest.h"
 
 extern bool verbose;
-extern const char *tmpdir;  // "/tmp" by default
+extern std::string tmpdir;
 extern bool tmpdir_on_tmpfs;
 extern bool force_mt;
 extern bool force_nofork;
@@ -56,9 +56,9 @@ void MaybeRunWithThread(Function fn) {
   }
 }
 
-// Return the absolute path of a filename in the temp directory
-// with the given pathname.  For the default "/tmp" temp directory,
-// this is just "/tmp/<pathname>".
+// Return the absolute path of a filename in the temp directory, `tmpdir`,
+// with the given pathname, e.g., "/tmp/<pathname>", if `tmpdir` was set to
+// "/tmp".
 const char *TmpFile(const char *pathname);
 
 // Run the given test function in a forked process, so that trapdoor

--- a/linux.cc
+++ b/linux.cc
@@ -350,7 +350,7 @@ TEST(Linux, fstatat) {
   close(cap_rf);
   close(fd);
 
-  int dir = open(tmpdir, O_RDONLY);
+  int dir = open(tmpdir.c_str(), O_RDONLY);
   EXPECT_OK(dir);
   int dir_rf = dup(dir);
   EXPECT_OK(dir_rf);
@@ -1364,7 +1364,7 @@ TEST(Linux, InvalidRightsSyscall) {
 
 FORK_TEST_ON(Linux, OpenByHandleAt, TmpFile("cap_openbyhandle_testfile")) {
   REQUIRE_ROOT();
-  int dir = open(tmpdir, O_RDONLY);
+  int dir = open(tmpdir.c_str(), O_RDONLY);
   EXPECT_OK(dir);
   int fd = openat(dir, "cap_openbyhandle_testfile", O_RDWR|O_CREAT, 0644);
   EXPECT_OK(fd);


### PR DESCRIPTION
One of the issues I noticed with the test suite is that it was
non-deterministic if interrupted, i.e., testcases that relied on a fresh
/tmp filesystem would fail on the second run if files were left behind.

Furthermore, some systems need `$TMPDIR` to not be hardcoded to `/tmp`,
e.g., ATF/Kyua (the defacto test runner/reporting infrastructure in FreeBSD
today). The fact that capsicum-test created files in `/tmp`, which was
outside of `$TMPDIR` [set by Kyua at runtime], means that it was
violating Kyua's sandboxing requirement.

This change uses tempnam to generate a temporary directory root at test
start via a `::testing::Environment` object (the global set of fixture hooks
provided by gtest), which it then uses to build other paths off of. If a
user provided path wasn't given, the directory root will be torn down at
test runner end, as best possible.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>