### PR TITLE
Fix clang warnings

### DIFF
--- a/capability-fd.cc
+++ b/capability-fd.cc
@@ -25,7 +25,7 @@ typedef struct {
   uint64_t right;
   const char* name;
 } right_info;
-right_info known_rights[] = {
+static right_info known_rights[] = {
   /* Rights that are common to all versions of Capsicum */
   RIGHTS_INFO(CAP_READ),
   RIGHTS_INFO(CAP_WRITE),

--- a/capmode.cc
+++ b/capmode.cc
@@ -627,7 +627,7 @@ FORK_TEST(Capmode, NewThread) {
 }
 
 static int had_signal = 0;
-static void handle_signal(int x) { had_signal = 1; }
+static void handle_signal(int) { had_signal = 1; }
 
 FORK_TEST(Capmode, SelfKill) {
   pid_t me = getpid();

--- a/capsicum-test.h
+++ b/capsicum-test.h
@@ -20,7 +20,7 @@ extern bool force_mt;
 extern bool force_nofork;
 extern uid_t other_uid;
 
-static inline void *WaitingThreadFn(void *p) {
+static inline void *WaitingThreadFn(void *) {
   // Loop until cancelled
   while (true) {
     usleep(10000);

--- a/mqueue.cc
+++ b/mqueue.cc
@@ -24,7 +24,7 @@
     static void test_case_name##_##test_name##_ForkTest()
 
 static bool invoked;
-void seen_it_done_it(int v) {
+void seen_it_done_it(int) {
   invoked = true;
 }
 

--- a/openat.cc
+++ b/openat.cc
@@ -11,9 +11,9 @@
 
 // Check an open call works and close the resulting fd.
 #define EXPECT_OPEN_OK(f) do { \
-    int fd = f;                \
-    EXPECT_OK(fd);             \
-    close(fd);                 \
+    int _fd = f;               \
+    EXPECT_OK(_fd);            \
+    close(_fd);                \
   } while (0)
 
 static void CreateFile(const char *filename, const char *contents) {

--- a/procdesc.cc
+++ b/procdesc.cc
@@ -223,7 +223,7 @@ TEST(Pdfork, NonProcessDescriptor) {
   close(fd);
 }
 
-static void *SubThreadMain(void *data) {
+static void *SubThreadMain(void *) {
   while (true) {
     if (verbose) fprintf(stderr, "      subthread: \"I aten't dead\"\n");
     usleep(100000);
@@ -231,7 +231,7 @@ static void *SubThreadMain(void *data) {
   return NULL;
 }
 
-static void *ThreadMain(void *data) {
+static void *ThreadMain(void *) {
   int pd;
   pid_t child = pdfork(&pd, 0);
   if (child == 0) {

--- a/syscalls.h
+++ b/syscalls.h
@@ -53,7 +53,7 @@ inline ssize_t flistxattr_(int fd, char *list, size_t size) {
 inline ssize_t fgetxattr_(int fd, const char *name, void *value, size_t size) {
   return extattr_get_fd(fd, EXTATTR_NAMESPACE_USER, name, value, size);
 }
-inline int fsetxattr_(int fd, const char *name, const void *value, size_t size, int flags) {
+inline int fsetxattr_(int fd, const char *name, const void *value, size_t size, int) {
   return extattr_set_fd(fd, EXTATTR_NAMESPACE_USER, name, value, size);
 }
 inline int fremovexattr_(int fd, const char *name) {


### PR DESCRIPTION
These changes fix some issues found when capsicum-test is built with `WARNS= 6` on FreeBSD.