### PR TITLE
Remove `FAIL` macro use for non-x86 architectures when testing `sysarch(2)`

### DIFF
--- a/capmode.cc
+++ b/capmode.cc
@@ -558,8 +558,7 @@ FORK_TEST_F(WithFiles, AllowedMiscSyscalls) {
   long sysarch_arg = 0;
   EXPECT_CAPMODE(sysarch(I386_SET_IOPERM, &sysarch_arg));
 #else
-  // TOOD(jra): write a test for arm
-  FAIL("capmode:no sysarch() test for current architecture");
+  // TOOD(jra): write a test for other architectures, like arm
 #endif
 #endif
 }


### PR DESCRIPTION
`FAIL()` does not support being called in the form noted in the test, 
which causes a test failure on non-x86 architectures.

The alternatives (use `ADD_TEST_FAILURE()` or `GTEST_SKIP()`) would be
misleading (in both cases), and in the case of `GTEST_SKIP()` is unavailable
on the version of googletest packaged with capsicum-test.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>