### PR TITLE
Improve failure mode if other_uid cannot be inferred

### DIFF
--- a/capability-fd.cc
+++ b/capability-fd.cc
@@ -1312,7 +1312,10 @@ TEST(Capability, NoBypassDACIfRoot) {
   pid_t child = fork();
   if (child == 0) {
     // Child: change uid to a lesser being
-    setuid(other_uid);
+    ASSERT_NE(0u, other_uid) << "other_uid not initialized correctly, "
+                                "please pass the -u <uid> flag.";
+    EXPECT_EQ(0, setuid(other_uid));
+    EXPECT_EQ(other_uid, getuid());
     // Attempt to fchmod the file, and fail.
     // Having CAP_FCHMOD doesn't bypass the need to comply with DAC policy.
     int rc = fchmod(fd, 0666);

--- a/procdesc.cc
+++ b/procdesc.cc
@@ -531,7 +531,10 @@ FORK_TEST(Pdfork, OtherUserIfRoot) {
   usleep(100);
 
   // Now that the second process has been pdfork()ed, change euid.
-  setuid(other_uid);
+  ASSERT_NE(0u, other_uid) << "other_uid not initialized correctly, "
+                              "please pass the -u <uid> flag.";
+  EXPECT_EQ(0, setuid(other_uid));
+  EXPECT_EQ(other_uid, getuid());
   if (verbose) fprintf(stderr, "uid=%d euid=%d\n", getuid(), geteuid());
 
   // Fail to kill child with normal PID operation.


### PR DESCRIPTION
If the capsicum-test binary is owned by root, we would infer other_uid as
root. This caused the tests that require another non-root UID to fail
because root can bypass some of the checks that would otherwise be in place.

To avoid surprising test failures, add an ASSERT_NE(0u, other_uid) with a
suggestion on how to fix this problem.