### PR TITLE
Close files after a failed EXPECT_OPENAT_FAIL_TRAVERSAL() check

### DIFF
--- a/capsicum-test.h
+++ b/capsicum-test.h
@@ -170,12 +170,14 @@ const char *TmpFile(const char *pathname);
       } else { \
         EXPECT_SYSCALL_FAIL(E_NO_TRAVERSE_CAPABILITY, result); \
       } \
+      if (result >= 0) { close(result); } \
     } while (0)
 #else
 #define EXPECT_OPENAT_FAIL_TRAVERSAL(fd, path, flags) \
     do { \
       const int result = openat((fd), (path), (flags)); \
       EXPECT_SYSCALL_FAIL(E_NO_TRAVERSE_CAPABILITY, result); \
+      if (result >= 0) { close(result); } \
     } while (0)
 #endif
 


### PR DESCRIPTION
In cases where EXPECT_OPENAT_FAIL_TRAVERSAL() fails, it wasn't closing the
file descriptor that openat() allocated.