### PR TITLE
Increase _RUN_FORKED timeout to 30s

### DIFF
--- a/capsicum-test.h
+++ b/capsicum-test.h
@@ -76,7 +76,7 @@ const char *TmpFile(const char *pathname);
       }                                                        \
     } else if (pid > 0) {                                      \
       int rc, status;                                          \
-      int remaining_us = 10000000;                             \
+      int remaining_us = 30000000;                             \
       while (remaining_us > 0) {                               \
         status = 0;                                            \
         rc = waitpid(pid, &status, WNOHANG);                   \


### PR DESCRIPTION
On busy (or emulated) systems, 10 seconds is sometimes not enough to
complete the entire test.