### PR TITLE
Speed up the Capability.SocketTransferForked test

### DIFF
--- a/capability-fd.cc
+++ b/capability-fd.cc
@@ -1020,6 +1020,8 @@ FORK_TEST_ON(Capability, SocketTransfer, TmpFile("cap_fd_transfer")) {
   if (child == 0) {
     // Child: enter cap mode
     EXPECT_OK(cap_enter());
+    // Child: send startup notification
+    SEND_INT_MESSAGE(sock_fds[0], MSG_CHILD_STARTED);
 
     // Child: wait to receive FD over socket
     int rc = recvmsg(sock_fds[0], &mh, 0);
@@ -1037,10 +1039,12 @@ FORK_TEST_ON(Capability, SocketTransfer, TmpFile("cap_fd_transfer")) {
     EXPECT_RIGHTS_EQ(&r_rs, &rights);
     TryReadWrite(cap_fd);
 
+    // Child: acknowledge that we have received and tested the file descriptor
+    SEND_INT_MESSAGE(sock_fds[0], MSG_CHILD_FD_RECEIVED);
+
     // Child: wait for a normal read
-    int val;
-    read(sock_fds[0], &val, sizeof(val));
-    exit(0);
+    AWAIT_INT_MESSAGE(sock_fds[0], MSG_PARENT_REQUEST_CHILD_EXIT);
+    exit(testing::Test::HasFailure());
   }
 
   int fd = open(TmpFile("cap_fd_transfer"), O_RDWR | O_CREAT, 0644);
@@ -1055,6 +1059,9 @@ FORK_TEST_ON(Capability, SocketTransfer, TmpFile("cap_fd_transfer")) {
   // Confirm we can do the right operations on the capability
   TryReadWrite(cap_fd);
 
+  // Wait for child to start up:
+  AWAIT_INT_MESSAGE(sock_fds[1], MSG_CHILD_STARTED);
+
   // Send the file descriptor over the pipe to the sub-process
   mh.msg_controllen = CMSG_LEN(sizeof(int));
   cmptr = CMSG_FIRSTHDR(&mh);
@@ -1064,13 +1071,14 @@ FORK_TEST_ON(Capability, SocketTransfer, TmpFile("cap_fd_transfer")) {
   *(int *)CMSG_DATA(cmptr) = cap_fd;
   buffer1[0] = 0;
   iov[0].iov_len = 1;
-  sleep(3);
   int rc = sendmsg(sock_fds[1], &mh, 0);
   EXPECT_OK(rc);
 
-  sleep(1);  // Ensure subprocess runs
-  int zero = 0;
-  write(sock_fds[1], &zero, sizeof(zero));
+  // Check that the child received the message
+  AWAIT_INT_MESSAGE(sock_fds[1], MSG_CHILD_FD_RECEIVED);
+
+  // Tell the child to exit
+  SEND_INT_MESSAGE(sock_fds[1], MSG_PARENT_REQUEST_CHILD_EXIT);
 }
 
 TEST(Capability, SyscallAt) {

--- a/capsicum-test.h
+++ b/capsicum-test.h
@@ -249,6 +249,27 @@ char ProcessState(int pid);
 #define EXPECT_PID_ZOMBIE(pid)  EXPECT_PID_REACHES_STATES(pid, 'Z', 'Z');
 #define EXPECT_PID_GONE(pid)    EXPECT_PID_REACHES_STATES(pid, '\0', '\0');
 
+enum {
+  // Magic numbers for messages sent by child processes.
+  MSG_CHILD_STARTED = 1234,
+  MSG_CHILD_FD_RECEIVED = 4321,
+  // Magic numbers for messages sent by parent processes.
+  MSG_PARENT_REQUEST_CHILD_EXIT = 9999,
+};
+
+#define SEND_INT_MESSAGE(fd, message) \
+  do { \
+    int _msg = message; \
+    EXPECT_EQ(sizeof(_msg), (size_t)write(fd, &_msg, sizeof(_msg))); \
+  } while (0)
+
+#define AWAIT_INT_MESSAGE(fd, expected) \
+  do {                                  \
+    int _msg = 0; \
+    EXPECT_EQ(sizeof(_msg), (size_t)read(fd, &_msg, sizeof(_msg))); \
+    EXPECT_EQ(expected, _msg); \
+  } while (0)
+
 // Mark a test that can only be run as root.
 #define GTEST_SKIP_IF_NOT_ROOT() \
   if (getuid() != 0) { GTEST_SKIP() << "requires root"; }


### PR DESCRIPTION
Instead of sleep()ing (which can be fragile), send additional messages
over the socket to synchronize with the child state.
On a single-CPU AArch64 QEMU this speeds up the test from ~5000ms to
~60ms (almost 1/8 of the total time).