### PR TITLE
Use libprocstat to get child process state on FreeBSD

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,6 +4,10 @@ OS:=$(shell uname)
 ARCH?=64
 ARCHFLAG=-m$(ARCH)
 
+ifeq ($(OS),FreeBSD)
+EXTRA_LIBS=-lprocstat
+endif
+
 ifeq ($(OS),Linux)
 PROCESSOR:=$(shell uname -p)
 

--- a/capsicum-test.cc
+++ b/capsicum-test.cc
@@ -110,6 +110,7 @@ char ProcessState(int pid) {
   }
   procstat_freeprocs(prstat, p);
   procstat_close(prstat);
+  if (verbose) fprintf(stderr, "Process %d in state '%c'\n", pid, result);
   return result;
 #endif
 }

--- a/capsicum-test.cc
+++ b/capsicum-test.cc
@@ -1,5 +1,15 @@
 #include "capsicum-test.h"
 
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#include <sys/proc.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#include <libprocstat.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
@@ -48,31 +58,46 @@ char ProcessState(int pid) {
   return '?';
 #endif
 #ifdef __FreeBSD__
-  char buffer[1024];
-  snprintf(buffer, sizeof(buffer), "ps -p %d -o state | grep -v STAT", pid);
-  sig_t original = signal(SIGCHLD, SIG_IGN);
-  FILE* cmd = popen(buffer, "r");
-  usleep(50000);  // allow any pending SIGCHLD signals to arrive
-  signal(SIGCHLD, original);
-  int result = fgetc(cmd);
-  fclose(cmd);
-  // Map FreeBSD codes to Linux codes.
-  switch (result) {
-    case EOF:
-      return '\0';
-    case 'D': // disk wait
-    case 'R': // runnable
-    case 'S': // sleeping
-    case 'T': // stopped
-    case 'Z': // zombie
-      return result;
-    case 'W': // idle interrupt thread
-      return 'S';
-    case 'I': // idle
-      return 'S';
-    case 'L': // waiting to acquire lock
-    default:
-      return '?';
+  unsigned int count = 0;
+  struct procstat *prstat = procstat_open_sysctl();
+  EXPECT_NE(NULL, prstat) << "procstat_open_sysctl failed.";
+  errno = 0;
+  struct kinfo_proc *p = procstat_getprocs(prstat, KERN_PROC_PID, pid, &count);
+  if (p == NULL || count == 0) {
+    if (verbose) fprintf(stderr, "procstat_getprocs failed with %p/%d: %s\n", p, count, strerror(errno));
+    procstat_close(prstat);
+    return '\0';
   }
+  char result = '\0';
+  // See state() in bin/ps/print.c
+  switch (p->ki_stat) {
+  case SSTOP:
+    result = 'T';
+    break;
+  case SSLEEP:
+    if (p->ki_tdflags & TDF_SINTR) /* interruptable (long) */
+      result = 'S';
+    else
+      result = 'D';
+    break;
+  case SRUN:
+  case SIDL:
+    result = 'R';
+    break;
+  case SWAIT:
+  case SLOCK:
+    // We treat SWAIT/SLOCK as 'S' here (instead of 'W'/'L').
+    result = 'S';
+    break;
+  case SZOMB:
+    result = 'Z';
+    break;
+  default:
+    result = '?';
+    break;
+  }
+  procstat_freeprocs(prstat, p);
+  procstat_close(prstat);
+  return result;
 #endif
 }

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ CXXFLAGS+=$(ARCHFLAG) -Wall -g $(GTEST_INCS) $(GTEST_FLAGS) --std=c++11
 CFLAGS+=$(ARCHFLAG) -Wall -g
 
 capsicum-test: $(OBJECTS) libgtest.a $(LOCAL_LIBS)
-	$(CXX) $(CXXFLAGS) -g -o $@ $(OBJECTS) libgtest.a -lpthread -lrt $(LIBSCTP) $(LIBCAPRIGHTS)
+	$(CXX) $(CXXFLAGS) -g -o $@ $(OBJECTS) libgtest.a -lpthread -lrt $(LIBSCTP) $(LIBCAPRIGHTS) $(EXTRA_LIBS)
 
 # Small statically-linked program for fexecve tests
 # (needs to be statically linked so that execve()ing it


### PR DESCRIPTION
I have been seeing intermittent failures in the CheriBSD that seem to
be happening due to the `signal(SIGCHLD, SIG_IGN)` call inside
ProcessState() that leads to child process not entering zombie state.

To avoid this race use libprocstat instead of forking a new ps process.
This is not only more reliable, but should also speed up the tests a bit
when running on slow emulated platforms.